### PR TITLE
Fixed `No module named six`

### DIFF
--- a/drfaddons/auth.py
+++ b/drfaddons/auth.py
@@ -43,7 +43,7 @@ class JSONWebTokenAuthenticationQS(BaseJSONWebTokenAuthentication):
 
             Hide some test client ickyness where the header can be unicode.
         """
-        from django.utils.six import text_type
+        from six import text_type
         from rest_framework import HTTP_HEADER_ENCODING
 
         auth = request.data.get(self.key, b'') or request.META.get(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ django-filter==2.0.0
 django-sendsms==0.3.1
 djangorestframework>=3.8.0
 djangorestframework-jwt==1.11.0
+six==1.13.0


### PR DESCRIPTION
Added six in requirements.txt, changed import from django.utils.six to six in auth.py