### PR TITLE
Update auth.py

### DIFF
--- a/drfaddons/auth.py
+++ b/drfaddons/auth.py
@@ -45,9 +45,8 @@ class JSONWebTokenAuthenticationQS(BaseJSONWebTokenAuthentication):
         """
         from six import text_type
         from rest_framework import HTTP_HEADER_ENCODING
-
-        auth = request.data.get(self.key, b'') or request.META.get(
-            self.header_key, b'')
+        
+        auth = request.META.get(self.header_key, b'')
 
         if isinstance(auth, text_type):
             # Work around django test client oddness


### PR DESCRIPTION
Removing `request.data.get(self.key, b'')` because:
- `request.data` doesn't have any key
-  This throws an error when a list is passed, because of this I can't send a list of dicts.